### PR TITLE
Fix bug in min_p sampling

### DIFF
--- a/mamba_ssm/utils/generation.py
+++ b/mamba_ssm/utils/generation.py
@@ -36,7 +36,7 @@ class InferenceParams:
 
 def modify_logits_for_min_p_filtering(logits, min_p):
     """Set the logits for none min_p values to -inf. Done in-place."""
-    if min_p <= 0.0 or min_p >= 1.0:
+    if (min_p <= 0.0).any() or (min_p >= 1.0).any():
         return
     indices_to_remove = logits < min_p
     logits.masked_fill_(indices_to_remove, float("-Inf"))
@@ -103,7 +103,7 @@ def sample(logits, top_k=1, top_p=0.0, min_p=0.0, temperature=1.0):
         else:
             if min_p > 0.0:
                 logits_top = logits.clone()
-                max_prob = logits_top[..., 0].item()
+                max_prob, _ = (torch.softmax(logits_top, dim=-1)).max(dim=-1, keepdim=True)
                 min_prob = max_prob * min_p
                 modify_logits_for_min_p_filtering(logits_top, min_prob)
                 if temperature != 1.0:


### PR DESCRIPTION
There is a bug in min_p sampling in pull request [#135](https://github.com/state-spaces/mamba/pull/135): The error `a Tensor with X elements cannot be converted to Scalar` is triggered in the line `max_prob = logits_top[..., 0].item()`.
In the example provided by the author, setting ``top_k=1`` does not actually invoke min_p sampling:
```
output_ids = model.generate(
        input_ids=input_ids,
        max_length=256,
        temperature=0.8,
        top_p=1,
        top_k=0,
        min_p=0.05
 )
```
because:
```
def sample(logits, top_k=1, top_p=0.0, min_p=0.0, temperature=1.0):
    """Sample from top-k logits.
    Arguments:
        logits: Tensor of shape (batch_size, vocab_size)
    """
    if top_k == 1:  # Short-circuit for greedy decoding
        return logits.argmax(dim=-1)
```
I have implemented the correct min_p sampling by referencing https://github.com/huggingface/transformers/pull/30639.